### PR TITLE
Fixes item swapping issues

### DIFF
--- a/AdiBags/widgets/ItemButton.lua
+++ b/AdiBags/widgets/ItemButton.lua
@@ -612,7 +612,7 @@ function stackProto:Update()
 	self:UpdateVisibleSlot()
 	self:UpdateCount()
 	if self.button then
-		self.button:Update()
+		self.button:FullUpdate()
 	end
 end
 


### PR DESCRIPTION
This should fix an annoying issue when you swap over two items in bags, they aren't updated as they should, resulting in wrong item stack count, icon, border, etc.