### PR TITLE
Add package addon workflow

### DIFF
--- a/.github/workflows/package-addon.yml
+++ b/.github/workflows/package-addon.yml
@@ -1,0 +1,55 @@
+name: Package World of Warcraft addon
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Addon version'
+        required: true
+
+jobs:
+  package:
+    name: Create zips and tag
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get name of addon
+      id: init
+      run: |
+        addon_name=$(ls *.toc)
+        addon_name=$(basename $addon_name .toc)
+        tag_name=${addon_name}-${{github.event.inputs.version}}
+        echo "::set-output name=addon_name::${addon_name}"
+        echo "::set-output name=tag_name::${tag_name}"
+    - name: Make folder for zips
+      run: |
+        mkdir -p .releases/${{steps.init.outputs.addon_name}}
+        rsync -r --exclude '.*' . .releases/${{steps.init.outputs.addon_name}}
+    - name: Create retail zip
+      run: |
+        cd .releases
+        zip -9 -r ${{steps.init.outputs.tag_name}}.zip ${{steps.init.outputs.addon_name}}
+        cd ..
+    - name: Tag this version
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{steps.init.outputs.tag_name}}
+        release_name: ${{steps.init.outputs.addon_name}} ${{github.event.inputs.version}}
+        body: ${{steps.init.outputs.addon_name}} ${{github.event.inputs.version}}
+        draft: false
+        prerelease: false
+
+    - name: Add retail zip to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: .releases/${{steps.init.outputs.tag_name}}.zip
+        asset_name: ${{steps.init.outputs.tag_name}}.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
This adds a new github workflow that will automatically package your addon and create a release for you in github.

To run you just goto the action and manually run the workflow.

Examples below using my own repo
<details>
<summary> expand to view </summary>

![image](https://user-images.githubusercontent.com/1134201/101394564-9e8f4d80-38c0-11eb-86ec-85bbf41f2445.png)

</details>